### PR TITLE
Bump plugin and dependencies to OpenSearch 3.1.0 and Lucene 10.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-extension</artifactId>
-	<version>3.0.1-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for language processing in OpenSearch, including tokenization and morphological analysis using Lucene analyzers.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-extension</url>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.0.0</opensearch.version>
-		<opensearch.runner.version>3.0.0.0</opensearch.runner.version>
+		<opensearch.version>3.1.0</opensearch.version>
+		<opensearch.runner.version>3.1.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.extension.ExtensionPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.1.0</lucene.version>
+		<lucene.version>10.2.1</lucene.version>
 		<log4j.version>2.21.0</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
This pull request updates the dependencies and versioning in the `pom.xml` file for the `opensearch-analysis-extension` project. The changes primarily involve upgrading the project version and its dependencies to align with newer releases.

### Version Updates:
* Updated the project version from `3.0.1-SNAPSHOT` to `3.1.0-SNAPSHOT`. (`pom.xml`, [pom.xmlL7-R7](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7))
* Upgraded OpenSearch and OpenSearch Runner versions from `3.0.0` and `3.0.0.0` to `3.1.0` and `3.1.0.0`, respectively. (`pom.xml`, [pom.xmlL39-R43](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R43))

### Dependency Updates:
* Updated `Lucene` version from `10.1.0` to `10.2.1`. (`pom.xml`, [pom.xmlL39-R43](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L39-R43))