### PR TITLE
chore: update OpenSearch to 3.6.0 and Lucene to 10.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-extension</artifactId>
-	<version>3.5.1-SNAPSHOT</version>
+	<version>3.6.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for language processing in OpenSearch, including tokenization and morphological analysis using Lucene analyzers.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-extension</url>
@@ -36,11 +36,11 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.5.0</opensearch.version>
-		<opensearch.runner.version>3.5.0.0</opensearch.runner.version>
+		<opensearch.version>3.6.0</opensearch.version>
+		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.extension.ExtensionPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
-		<lucene.version>10.3.2</lucene.version>
+		<lucene.version>10.4.0</lucene.version>
 		<log4j.version>2.25.3</log4j.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
## Summary
Update dependencies to align with OpenSearch 3.6.0 release and Lucene 10.4.0.

## Changes Made
- Bump project version from `3.5.1-SNAPSHOT` to `3.6.0-SNAPSHOT`
- Update OpenSearch dependency from `3.5.0` to `3.6.0`
- Update OpenSearch Runner from `3.5.0.0` to `3.6.0.0`
- Update Lucene from `10.3.2` to `10.4.0`

## Testing
- Run `mvn package` to verify the build succeeds with updated dependencies
- Run `mvn test` to ensure all tests pass

## Breaking Changes
- None expected. This is a dependency version bump.

## Additional Notes
- Follows the same pattern as previous version updates (e.g., #10)