### PR TITLE
chore: update OpenSearch to 3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ A comprehensive text analysis plugin for OpenSearch that provides advanced token
 ## Tech Stack
 
 - **Java**: 21
-- **OpenSearch**: 3.2.0
-- **Lucene**: 10.2.2
+- **OpenSearch**: 3.7.0
+- **Lucene**: 10.4.0
 - **Build System**: Maven 3.x
 - **Testing**: JUnit 4.13.2
 
@@ -26,14 +26,14 @@ A comprehensive text analysis plugin for OpenSearch that provides advanced token
 
 ### Prerequisites
 
-- OpenSearch 3.2.0 or later
+- OpenSearch 3.7.0 or later
 - Java 21 or later (for building from source)
 
 ### Installation
 
 #### From Maven Repository
 ```bash
-$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs:opensearch-analysis-extension:3.2.0
+$OPENSEARCH_HOME/bin/opensearch-plugin install org.codelibs:opensearch-analysis-extension:3.7.0
 ```
 
 #### From Local Build
@@ -44,7 +44,7 @@ cd opensearch-analysis-extension
 mvn package
 
 # Install plugin
-$OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-analysis-extension-3.2.0.zip
+$OPENSEARCH_HOME/bin/opensearch-plugin install file:target/releases/opensearch-analysis-extension-3.7.0.zip
 ```
 
 ### Basic Usage Example
@@ -393,6 +393,8 @@ mvn jacoco:report
 
 | Plugin Version | OpenSearch Version | Lucene Version | Java Version |
 |:---------------|:-------------------|:---------------|:-------------|
+| 3.7.x | 3.7.0+ | 10.4.0+ | 21+ |
+| 3.6.x | 3.6.0+ | 10.4.0+ | 21+ |
 | 3.2.x | 3.2.0+ | 10.2.2+ | 21+ |
 | 3.1.x | 3.1.0+ | 10.1.x+ | 21+ |
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.codelibs.opensearch</groupId>
 	<artifactId>opensearch-analysis-extension</artifactId>
-	<version>3.6.1-SNAPSHOT</version>
+	<version>3.7.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<description>This plugin provides an analysis library for language processing in OpenSearch, including tokenization and morphological analysis using Lucene analyzers.</description>
 	<url>https://github.com/codelibs/opensearch-analysis-extension</url>
@@ -36,8 +36,8 @@
 	  <tag>HEAD</tag>
   </scm>
 	<properties>
-		<opensearch.version>3.6.0</opensearch.version>
-		<opensearch.runner.version>3.6.0.0</opensearch.runner.version>
+		<opensearch.version>3.7.0</opensearch.version>
+		<opensearch.runner.version>3.7.0.0</opensearch.runner.version>
 		<opensearch.plugin.classname>org.codelibs.opensearch.extension.ExtensionPlugin</opensearch.plugin.classname>
 		<maven.compiler.target>21</maven.compiler.target>
 		<lucene.version>10.4.0</lucene.version>


### PR DESCRIPTION
## Summary
Updates the plugin to OpenSearch 3.7.0, following the same pattern as the 3.6.0 upgrade (#11). OpenSearch 3.7.0 still depends on Lucene 10.4.0, so no Lucene change is needed this time.

## Changes Made
- Bump project version to `3.7.0-SNAPSHOT`
- Update OpenSearch dependency from 3.6.0 to 3.7.0
- Update OpenSearch Runner from 3.6.0.0 to 3.7.0.0
- Refresh stale version references in README (Tech Stack, prerequisites, install examples) and add 3.7.x / 3.6.x rows to the version compatibility table

## Testing
- `mvn package` builds successfully
- All 153 unit tests pass, including the `OpenSearchRunner`-based integration tests against OpenSearch 3.7.0

## Breaking Changes
- None

## Additional Notes
- Verified against the OpenSearch 3.7.0 POM on Maven Central that the Lucene dependency remains 10.4.0, so `lucene.version` is unchanged