### PR TITLE
build: attach sources and javadoc jars to release builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,18 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.3.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar-no-fork</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>3.11.2</version>
 				<configuration>
@@ -72,6 +84,14 @@
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
 				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
## Summary
Release builds were not attaching sources and javadoc jars to published artifacts. This is the same issue fixed in codelibs/opensearch-runner#20 (25c54af).

The `release:perform` goal did not generate these jars because `maven-source-plugin` was missing from the build and `maven-javadoc-plugin` had no `jar` goal execution. The super POM release-profile that used to handle this is no longer available in current Maven versions.

## Changes Made
- Add `maven-source-plugin` 3.3.1 with an `attach-sources` execution (`jar-no-fork` goal)
- Add an `attach-javadocs` execution (`jar` goal) to the existing `maven-javadoc-plugin`

## Testing
- Ran `mvn package -DskipTests=true` and confirmed all three artifacts are generated:
  - `opensearch-analysis-extension-3.7.0-SNAPSHOT.jar`
  - `opensearch-analysis-extension-3.7.0-SNAPSHOT-sources.jar`
  - `opensearch-analysis-extension-3.7.0-SNAPSHOT-javadoc.jar`

## Breaking Changes
- None

## Additional Notes
- Mirrors the fix applied to opensearch-runner so release artifacts published to Maven Central include sources and javadoc jars as required.