### PR TITLE
build(pom): pin maven-source-plugin to 3.2.1 to avoid duplicate sources jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.3.1</version>
+				<version>3.2.1</version><!-- https://issues.apache.org/jira/browse/MSOURCES-143 -->
 				<executions>
 					<execution>
 						<id>attach-sources</id>


### PR DESCRIPTION
## Summary
The Jenkins deploy job fails with `We have duplicated artifacts attached` because the `attach-sources` execution (maven-source-plugin 3.3.1) attaches a sources jar that the job's command-line `source:jar` goal has already attached. Since 3.3.0, maven-source-plugin fails on duplicate attachment instead of silently overwriting ([MSOURCES-143](https://issues.apache.org/jira/browse/MSOURCES-143)).

## Changes Made
- Pin `maven-source-plugin` to 3.2.1, with a comment pointing to MSOURCES-143
- Same fix as codelibs/curl4j#18 and codelibs/corelib#22

## Testing
- `mvn clean source:jar package -DskipTests` succeeds locally and the sources jar is built and attached correctly